### PR TITLE
Upstream has changed camel's binary location, follow suit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ install:
 	go install $(CORE_IMAGES)
 	go build -o $(GOPATH)/bin/kafka-source-controller ./kafka/source/cmd/controller
 	go build -o $(GOPATH)/bin/kafka-source-adapter ./kafka/source/cmd/receive_adapter
-	go build -o $(GOPATH)/bin/camel-source-controller ./contrib/camel/cmd/controller
+	go build -o $(GOPATH)/bin/camel-source-controller ./camel/source/cmd/controller
 	go build -o $(GOPATH)/bin/github-source-controller ./contrib/github/cmd/controller
 	go build -o $(GOPATH)/bin/github-receive-adapter ./contrib/github/cmd/receive_adapter
 source.adapter: install

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -23,7 +23,7 @@ function resolve_resources(){
         -e "s+github.com/knative/eventing-sources/kafka/source/cmd/receive_adapter+${image_prefix}kafka-source-adapter${image_tag}+" \
         -e "s+github.com/knative/eventing-sources/kafka/source/cmd/controller+${image_prefix}kafka-source-controller${image_tag}+" \
         -e "s+github.com/knative/eventing-sources/contrib/github/cmd/github_receive_adapter+${image_prefix}github-receive-adapter${image_tag}+" \
-        -e "s+github.com/knative/eventing-contrib/contrib/camel/cmd/controller+${image_prefix}camel-source-controller${image_tag}+" \
+        -e "s+github.com/knative/eventing-contrib/camel/source/cmd/controller+${image_prefix}camel-source-controller${image_tag}+" \
         -e "s+github.com/knative/eventing-contrib/kafka/source/cmd/receive_adapter+${image_prefix}kafka-source-adapter${image_tag}+" \
         -e "s+github.com/knative/eventing-contrib/kafka/source/cmd/controller+${image_prefix}kafka-source-controller${image_tag}+" \
         -e "s+github.com/knative/eventing-contrib/contrib/github/cmd/github_receive_adapter+${image_prefix}github-receive-adapter${image_tag}+" \


### PR DESCRIPTION
https://github.com/knative/eventing-contrib/pull/466 moves camel binaries to match kafka's layout.  We need to alter our makefile & resolve.sh to match