### PR TITLE
Adding NetworkPolicy workaround for webhook

### DIFF
--- a/openshift/release/knative-eventing-kafka-contrib-v0.8.2.yaml
+++ b/openshift/release/knative-eventing-kafka-contrib-v0.8.2.yaml
@@ -1030,3 +1030,17 @@ spec:
         - name: config-logging
           configMap:
             name: config-logging
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kafka-webhook
+  namespace: knative-eventing
+  labels:
+    app: kafka-webhook
+spec:
+  podSelector:
+    matchLabels:
+      app: kafka-webhook
+  ingress:
+  - {}


### PR DESCRIPTION
Porting https://github.com/openshift/knative-eventing/commit/e5ad9c59fe03f6abee0469be7e0f1bd07c3bb9e3

to here (since w/ 0.8.x channels are no longer in _CORE_) 