### PR TITLE
Adding NetworkPolicy workaround for webhook

### DIFF
--- a/openshift/release/knative-eventing-kafka-contrib-v0.9.0.yaml
+++ b/openshift/release/knative-eventing-kafka-contrib-v0.9.0.yaml
@@ -817,3 +817,18 @@ spec:
         - name: config-logging
           configMap:
             name: config-logging
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kafka-webhook
+  namespace: knative-eventing
+  labels:
+    app: kafka-webhook
+spec:
+  podSelector:
+    matchLabels:
+      app: kafka-webhook
+  ingress:
+  - {}
+


### PR DESCRIPTION
porting fix to 0.9.0 (was done for 0.8.2 before)