### PR TITLE
fixing incorrectly generated metrics domain vals

### DIFF
--- a/openshift/release/knative-eventing-kafka-contrib-v0.10.0.yaml
+++ b/openshift/release/knative-eventing-kafka-contrib-v0.10.0.yaml
@@ -344,7 +344,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: METRICS_DOMAIN
-          value: quay.io/openshift-knative/knative-eventing-sources-sources:v0.10.0
+          value: knative.dev/sources
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
         - name: KAFKA_RA_IMAGE
@@ -907,7 +907,7 @@ spec:
             - name: CONFIG_LOGGING_NAME
               value: config-logging
             - name: METRICS_DOMAIN
-              value: quay.io/openshift-knative/knative-eventing-sources-eventing:v0.10.0
+              value: knative.dev/eventing
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -954,7 +954,7 @@ spec:
             - name: CONFIG_LOGGING_NAME
               value: config-logging
             - name: METRICS_DOMAIN
-              value: quay.io/openshift-knative/knative-eventing-sources-eventing:v0.10.0
+              value: knative.dev/eventing
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -1023,7 +1023,7 @@ spec:
           - name: CONFIG_LOGGING_NAME
             value: config-logging
           - name: METRICS_DOMAIN
-            value: quay.io/openshift-knative/knative-eventing-sources-eventing:v0.10.0
+            value: knative.dev/eventing
           - name: WEBHOOK_NAME
             value: kafka-webhook
         ports:


### PR DESCRIPTION
the generated "midstream release" yaml (the one that points to our quay.io images) was incorrectly created.  the script (`resolver script` ) did put in some wrong value for the METRICS_DOMAIN.

Attached is a manual fix, so that we can use the file