### PR TITLE
Ci updates

### DIFF
--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -22,9 +22,7 @@ test -d "$CONFIGDIR" || fail "'$CONFIGDIR' is not a directory"
 # Generate CI config files
 CONFIG=$CONFIGDIR/openshift-knative-eventing-contrib-release-v$VERSION
 CURDIR=$(dirname $0)
-$CURDIR/generate-ci-config.sh knative-v$VERSION 4.3 > ${CONFIG}.yaml
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.4 true > ${CONFIG}__44.yaml
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.5 true > ${CONFIG}__45.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.5 > ${CONFIG}.yaml
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.6 true > ${CONFIG}__46.yaml
 
 # Append missing lines to the mirror file.


### PR DESCRIPTION
* adding source image (like we have on `knative-eventing`)
* just use 4.5 and 4.6 on the CI runs