### PR TITLE
Updating to more recent eventing lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
-	knative.dev/eventing v0.17.3-0.20200831120208-4051c5d96eda
+	knative.dev/eventing v0.17.5-0.20200925065343-049b8e743bd4
 	knative.dev/pkg v0.0.0-20200824160247-5343c1d19369
 	knative.dev/serving v0.17.1
 	knative.dev/test-infra v0.0.0-20200828171708-f68cb78c80a9

--- a/go.sum
+++ b/go.sum
@@ -2028,8 +2028,8 @@ k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 knative.dev/caching v0.0.0-20190719140829-2032732871ff/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
 knative.dev/caching v0.0.0-20200116200605-67bca2c83dfa/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
 knative.dev/caching v0.0.0-20200811171106-48c335fed9c8/go.mod h1:XonDcFC2DLSWP71f2y7oYnXUko5d5HsJRnZtkp0wY7g=
-knative.dev/eventing v0.17.3-0.20200831120208-4051c5d96eda h1:jSlRWGYHXiUydx0BMJ1Vrka74qNDC1LQy/KnUO2TDek=
-knative.dev/eventing v0.17.3-0.20200831120208-4051c5d96eda/go.mod h1:9NwCSwLnMCKmgz3YQBNax18mSgBjud8CvfsUUVOZ1sA=
+knative.dev/eventing v0.17.5-0.20200925065343-049b8e743bd4 h1:Wygx5VC4nZDs9p1Om8EYWqHMSNDZ6gWhio09hj0KVMw=
+knative.dev/eventing v0.17.5-0.20200925065343-049b8e743bd4/go.mod h1:9NwCSwLnMCKmgz3YQBNax18mSgBjud8CvfsUUVOZ1sA=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/eventing-contrib v0.11.2/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/networking v0.0.0-20200812200006-4d518e76538a h1:E1rnQR9IZvDcEAgoOXMW9LWqevaYFVTlMS2ndgoAO6Y=

--- a/vendor/knative.dev/eventing/test/e2e/helpers/broker_redelivery_helper.go
+++ b/vendor/knative.dev/eventing/test/e2e/helpers/broker_redelivery_helper.go
@@ -40,8 +40,7 @@ func BrokerRedelivery(t *testing.T, creator BrokerCreatorWithRetries) {
 
 	t.Run(dropevents.Fibonacci, func(t *testing.T) {
 		brokerRedelivery(t, creator, numRetries, func(pod *corev1.Pod, client *testlib.Client) error {
-			container := pod.Spec.Containers[0]
-			container.Env = append(container.Env,
+			pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env,
 				corev1.EnvVar{
 					Name:  dropevents.SkipAlgorithmKey,
 					Value: dropevents.Fibonacci,
@@ -53,15 +52,14 @@ func BrokerRedelivery(t *testing.T, creator BrokerCreatorWithRetries) {
 
 	t.Run(dropevents.Sequence, func(t *testing.T) {
 		brokerRedelivery(t, creator, numRetries, func(pod *corev1.Pod, client *testlib.Client) error {
-			container := pod.Spec.Containers[0]
-			container.Env = append(container.Env,
+			pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env,
 				corev1.EnvVar{
 					Name:  dropevents.SkipAlgorithmKey,
 					Value: dropevents.Sequence,
 				},
 				corev1.EnvVar{
 					Name:  dropevents.NumberKey,
-					Value: fmt.Sprintf("%d", numRetries-1),
+					Value: fmt.Sprintf("%d", numRetries),
 				},
 			)
 			return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1145,7 +1145,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/eventing v0.17.3-0.20200831120208-4051c5d96eda
+# knative.dev/eventing v0.17.5-0.20200925065343-049b8e743bd4
 ## explicit
 knative.dev/eventing/pkg/adapter/v2
 knative.dev/eventing/pkg/adapter/v2/test


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

/hold
until https://github.com/openshift/knative-eventing/pull/857 is in

Context is porting upstream 1609 to here...
