### PR TITLE
[0.17] Create temporary tracing config in /tmp

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -112,9 +112,9 @@ function install_knative_kafka(){
 function run_e2e_tests(){
 
   oc get ns ${TEST_EVENTING_NAMESPACE} 2>/dev/null || TEST_EVENTING_NAMESPACE="knative-eventing"
-  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} > tmp.tracing.config.yaml
-  oc replace -f tmp.tracing.config.yaml
-  rm tmp.tracing.config.yaml
+  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} > /tmp/tmp.tracing.config.yaml
+  oc replace -f /tmp/tmp.tracing.config.yaml
+  rm /tmp/tmp.tracing.config.yaml
   local test_name="${1:-}"
   local run_command=""
   local failed=0

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -112,9 +112,7 @@ function install_knative_kafka(){
 function run_e2e_tests(){
 
   oc get ns ${TEST_EVENTING_NAMESPACE} 2>/dev/null || TEST_EVENTING_NAMESPACE="knative-eventing"
-  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} > /tmp/tmp.tracing.config.yaml
-  oc replace -f /tmp/tmp.tracing.config.yaml
-  rm /tmp/tmp.tracing.config.yaml
+  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} | oc replace -f -
   local test_name="${1:-}"
   local run_command=""
   local failed=0

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -125,7 +125,7 @@ function run_e2e_tests(){
 
   go_test_e2e -timeout=90m -parallel=12 ./test/e2e \
     "$run_command" \
-    $common_opts --dockerrepo "quay.io/openshift-knative" || failed=$?
+    $common_opts --dockerrepo "quay.io/openshift-knative" --imagetemplate "quay.io/openshift-knative/{{.Name}}:v0.14.0" || failed=$?
 
   return $failed
 }


### PR DESCRIPTION
Getting permission denied when eventing-contrib e2e tests are run by S-O
Context: https://github.com/openshift-knative/serverless-operator/pull/520#issuecomment-705411536

To be ported to 0.18 and master later