### PR TITLE
[0.17] Updating the product base to 1.10 release

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -68,7 +68,7 @@ function install_serverless(){
   header "Installing Serverless Operator"
   local operator_dir=/tmp/serverless-operator
   local failed=0
-  git clone --branch release-1.9 https://github.com/openshift-knative/serverless-operator.git $operator_dir
+  git clone --branch release-1.10 https://github.com/openshift-knative/serverless-operator.git $operator_dir
   cp openshift/serverless.bash $operator_dir/hack/lib/serverless.bash
   # unset OPENSHIFT_BUILD_NAMESPACE as its used in serverless-operator's CI environment as a switch
   # to use CI built images, we want pre-built images of k-s-o and k-o-i

--- a/openshift/serverless.bash
+++ b/openshift/serverless.bash
@@ -82,7 +82,7 @@ function approve_csv {
   channel=$2
 
   # Ensure channel and source is set properly
-  oc patch subscription "$OPERATOR" -n "${OPERATORS_NAMESPACE}" \
+  oc patch subscriptions.operators.coreos.com "$OPERATOR" -n "${OPERATORS_NAMESPACE}" \
     --type 'merge' \
     --patch '{"spec": {"channel": "'"${channel}"'", "source": "'"${OLM_SOURCE}"'"}}' \
     || return $?
@@ -103,7 +103,7 @@ function find_install_plan {
   local csv=$1
   for plan in `oc get installplan -n ${OPERATORS_NAMESPACE} --no-headers -o name`; do 
     [[ $(oc get $plan -n ${OPERATORS_NAMESPACE} -o=jsonpath='{.spec.clusterServiceVersionNames}' | grep -c $csv) -eq 1 && \
-       $(oc get $plan -n ${OPERATORS_NAMESPACE} -o=jsonpath="{.status.bundleLookups[0].catalogSourceRef.name}" | grep -c $OPERATOR) -eq 1 ]] && echo $plan && return 0
+       $(oc get $plan -n ${OPERATORS_NAMESPACE} -o=jsonpath="{.status.bundleLookups[0].catalogSourceRef.name}" | grep -c $OLM_SOURCE) -eq 1 ]] && echo $plan && return 0
   done
   echo ""
 }
@@ -145,7 +145,7 @@ function teardown_serverless {
   logger.info 'Ensure no knative eventing pods running'
   timeout 600 "[[ \$(oc get pods -n ${EVENTING_NAMESPACE} --field-selector=status.phase!=Succeeded -o jsonpath='{.items}') != '[]' ]]" || return 9
 
-  oc delete subscription -n "${OPERATORS_NAMESPACE}" "${OPERATOR}" 2>/dev/null
+  oc delete subscriptions.operators.coreos.com -n "${OPERATORS_NAMESPACE}" "${OPERATOR}" 2>/dev/null
   for ip in $(oc get installplan -n "${OPERATORS_NAMESPACE}" | grep serverless-operator | cut -f1 -d' '); do
     oc delete installplan -n "${OPERATORS_NAMESPACE}" $ip
   done


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Using the serverless 1.10 operator branch 

