### PR TITLE
Setting default zap logger to 'info'

### DIFF
--- a/kafka/source/config/config-observability.yaml
+++ b/kafka/source/config/config-observability.yaml
@@ -22,8 +22,8 @@ data:
   # Common configuration for all Knative codebase
   zap-logger-config: |
     {
-      "level": "debug",
-      "development": true,
+      "level": "info",
+      "development": false,
       "outputPaths": ["stdout"],
       "errorOutputPaths": ["stderr"],
       "encoding": "json",


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

applying to 0.17 as well....