### PR TITLE
Moving the secret creation inside the test runner...

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -272,6 +272,9 @@ function uninstall_knative_kafka_source(){
 
 function run_e2e_tests(){
 
+  # the source tests REQUIRE the secrets, hence we create it here:
+  create_auth_secrets || return 1
+
   oc get ns ${TEST_EVENTING_NAMESPACE} 2>/dev/null || TEST_EVENTING_NAMESPACE="knative-eventing"
   sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${TEST_EVENTING_NAMESPACE}/g" ${CONFIG_TRACING_CONFIG} | oc replace -f -
   local test_name="${1:-}"

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -23,8 +23,6 @@ failed=0
 
 (( !failed )) && install_tracing || failed=1
 
-(( !failed )) && create_auth_secrets || failed=1
-
 (( !failed )) && run_e2e_tests || failed=1
 
 (( !failed )) && uinstall_knative_kafka || failed=1


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>


With this: we ensure that every _caller_ of the `run_e2e_tests` does **NOT** need to ensure the secrets are created
