### PR TITLE
[0.18] Disable repo_gpgcheck for kube repo in build image

### DIFF
--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -3,5 +3,5 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg


### PR DESCRIPTION
This is a fix according to kubernetes/kubernetes#60134 . The build image includes GnuPG 2.0.22 which shows this problem,

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>