### PR TITLE
[0.17] Disable repo_gpgcheck for kube repo in build image

### DIFF
--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -3,5 +3,5 @@ name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
+repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -2,7 +2,6 @@
 
 export EVENTING_NAMESPACE="${EVENTING_NAMESPACE:-knative-eventing}"
 export ZIPKIN_NAMESPACE=$EVENTING_NAMESPACE
-export OLM_NAMESPACE=openshift-marketplace
 
 function scale_up_workers(){
   local cluster_api_ns="openshift-machine-api"
@@ -148,14 +147,14 @@ function install_serverless(){
   header "Installing Serverless Operator"
   local operator_dir=/tmp/serverless-operator
   local failed=0
-  git clone --branch release-1.10 https://github.com/openshift-knative/serverless-operator.git $operator_dir
-  cp openshift/serverless.bash $operator_dir/hack/lib/serverless.bash
+  git clone --branch release-1.12 https://github.com/openshift-knative/serverless-operator.git $operator_dir || return 1
   # unset OPENSHIFT_BUILD_NAMESPACE (old CI) and OPENSHIFT_CI (new CI) as its used in serverless-operator's CI
   # environment as a switch to use CI built images, we want pre-built images of k-s-o and k-o-i
   unset OPENSHIFT_BUILD_NAMESPACE
   unset OPENSHIFT_CI
   pushd $operator_dir
-  ./hack/install.sh && header "Serverless Operator installed successfully" || failed=1
+
+  INSTALL_EVENTING="false" ./hack/install.sh && header "Serverless Operator installed successfully" || failed=1
   popd
   return $failed
 }

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -130,10 +130,9 @@ function install_strimzi(){
   strimzi_version=`curl https://github.com/strimzi/strimzi-kafka-operator/releases/latest |  awk -F 'tag/' '{print $2}' | awk -F '"' '{print $1}' 2>/dev/null`
   header "Strimzi install"
   oc create namespace kafka
-  oc -n kafka apply --selector strimzi.io/crd-install=true -f "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml"
   curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimzi_version}/strimzi-cluster-operator-${strimzi_version}.yaml" \
   | sed 's/namespace: .*/namespace: kafka/' \
-  | oc -n kafka apply -f -
+  | oc -n kafka create -f -
 
   # Wait for the CRD we need to actually be active
   oc wait crd --timeout=-1s kafkas.kafka.strimzi.io --for=condition=Established


### PR DESCRIPTION
This is a fix according to kubernetes/kubernetes#60134 . The build image includes GnuPG 2.0.22 which shows this problem

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>